### PR TITLE
Added nodejs-portable-runtime

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -108,5 +108,9 @@
     {
         "github_url": "https://github.com/infinitus/nusmods-gem",
         "tags": ["nus"]
+    },
+    {
+        "github_url": "https://github.com/yjwong/nodejs-portable-runtime",
+        "tags" ["script", "nodejs"]
     }
 ]


### PR DESCRIPTION
This is a set of scripts that enables easy and portable deployment of Node.js and npm on Windows.
Good for those of you who don't want to install Node.js or just want it on a thumbdrive for easy demonstration.
